### PR TITLE
[SVC-DSC-7] Implement service discovery heartbeat

### DIFF
--- a/docs/tasks/dst-pfm.md
+++ b/docs/tasks/dst-pfm.md
@@ -2,9 +2,9 @@
 
 - Platform layer
 
-## DST-PFM-1 - Common lib
+## DST-PFM-1 - Common lib [PR](https://github.com/Dolpheyn/dist-rust-buted/pull/12)
 
-- [ ] Extract platform-layer routines and utils to a common library
+- [x] Extract platform-layer routines and utils to a common library
 
 ## DST-PFM-0 - Graceful shutdown [PR](https://github.com/Dolpheyn/dist-rust-buted/pull/7)
 

--- a/docs/tasks/svc-dsc.md
+++ b/docs/tasks/svc-dsc.md
@@ -6,6 +6,13 @@
   - Basic DynamoDB table
     - PK: ServiceGroup, SK: ServiceName, IP:port (string)
 
+## SVC-DSC-7 - Server sends heartbeat, Service discovery listens [PR](https://github.com/Dolpheyn/dist-rust-buted/pull/13)
+
+- [x] Save last register message timestamp in service map
+- [x] after svc-dsc is served, check each service in map in interval (10 secs).
+  - If timestamp is more than 10 seconds ago, assume service is dead, deregister service.
+- [x] After serving registered services, call register in intervals(10 secs).
+
 ## SVC-DSC-6 - Client sdk
 
 - [x] Add .env file storing serdict's port

--- a/src/dst_pfm/lib.rs
+++ b/src/dst_pfm/lib.rs
@@ -22,10 +22,6 @@ pub struct ServiceConfig {
 }
 
 async fn init_service(cfg: &ServiceConfig) -> Result<(), Box<dyn std::error::Error>> {
-    let mut svc_dsc_client = svc_dsc::client::client()
-        .await
-        .expect("dst-pfm::init_service: unable to connect to svc_dsc");
-
     let ServiceConfig {
         service_group,
         service_name,
@@ -35,6 +31,10 @@ async fn init_service(cfg: &ServiceConfig) -> Result<(), Box<dyn std::error::Err
     } = cfg;
 
     if *should_register {
+        let mut svc_dsc_client = svc_dsc::client::client()
+            .await
+            .expect("dst-pfm::init_service: unable to connect to svc_dsc");
+
         println!(
             "dst-pfm::init_service: registering {}/{} at {}:{}",
             service_group, service_name, host, port

--- a/src/dst_pfm/mod.rs
+++ b/src/dst_pfm/mod.rs
@@ -1,2 +1,2 @@
 pub mod lib;
-pub use lib::*;
+pub use lib::{serve_with_shutdown, ServiceConfig};

--- a/src/svc_dsc/mod.rs
+++ b/src/svc_dsc/mod.rs
@@ -5,5 +5,8 @@ pub use gen::*;
 
 pub mod client;
 
+// in millis
+pub const HEARTBEAT_INTERVAL: u64 = 10000;
+
 pub const SERVICE_GROUP: &str = "platform";
 pub const SERVICE_NAME: &str = "service_discovery";


### PR DESCRIPTION
- SerDict will check its service registry and de-register any services that hasn't announced (re-register) its liveliness within the defined interval `HEARTBEAT_INTERVAL`

## Demo

(**before** making registered services re-register every `HEARTBEAT_INTERVAL`)
svc_dsc drops svc_mat_add

https://user-images.githubusercontent.com/47665123/221346194-8cda7666-d1c5-417d-bf0b-0ea012c6aa4f.mov


(**after** making registered services re-register every `HEARTBEAT_INTERVAL`)
svc_dsc keeps all registered services

https://user-images.githubusercontent.com/47665123/221346458-bcf88227-a917-4308-aa02-cea82ed77fbe.mp4

